### PR TITLE
Defensive against CSS style minification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.log
 .idea
 dist
+junit.xml

--- a/aspect-ratio.css
+++ b/aspect-ratio.css
@@ -9,6 +9,7 @@
     position: relative;
   }
   [style*="--aspect-ratio"]::before {
+    height: 0;
     content: "";
     display: block;
     padding-bottom: calc(100% / (var(--aspect-ratio)));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-aspect-ratio",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "React Aspect Ratio Component",
   "author": "Roderick Hsiao <roderickhsiao@gmail.com>",
   "repository": {

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`Aspect Ratio custom style willl be adpoted 1`] = `
   className="react-aspect-ratio-placeholder"
   style={
     Object {
-      "--aspect-ratio": "4/3",
+      "--aspect-ratio": "(4/3)",
       "color": "#fff",
     }
   }
@@ -22,7 +22,7 @@ exports[`Aspect Ratio should render wrapper for children 1`] = `
   className="react-aspect-ratio-placeholder"
   style={
     Object {
-      "--aspect-ratio": "4/3",
+      "--aspect-ratio": "(4/3)",
     }
   }
 >

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -32,3 +32,19 @@ exports[`Aspect Ratio should render wrapper for children 1`] = `
   />
 </div>
 `;
+
+exports[`Aspect Ratio should support number as props 1`] = `
+<div
+  className="react-aspect-ratio-placeholder"
+  style={
+    Object {
+      "--aspect-ratio": "(0.75)",
+    }
+  }
+>
+  <img
+    alt="demo"
+    src="https://foo.bar"
+  />
+</div>
+`;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -10,6 +10,12 @@ describe('Aspect Ratio', () => {
     expect(node).toMatchSnapshot();
   });
 
+  it('should support number as props', () => {
+    const innerImage = <img src="https://foo.bar" alt="demo" />;
+    const node = renderer.create(<AspectRatio ratio={0.75}>{innerImage}</AspectRatio>).toJSON();
+    expect(node).toMatchSnapshot();
+  });
+
   it('custom style willl be adpoted', () => {
     const innerImage = <img src="https://foo.bar" alt="demo" />;
     const node = renderer

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,13 @@ import { polyfill } from 'react-lifecycles-compat';
 const CUSTOM_PROPERTY_NAME = '--aspect-ratio';
 
 type Props = {
-  ratio?: string | number,
+  ratio: string | number,
   style: Object,
   children: Object
 };
 
 type State = {
-  ratio?: string | number
+  ratio: string | number
 };
 
 class AspectRatio extends PureComponent<Props, State> {

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ class AspectRatio extends PureComponent<Props, State> {
       // check if React support custom property AFTER
       const customPropertyValue = node.style.getPropertyValue(CUSTOM_PROPERTY_NAME);
       if (!customPropertyValue) {
-        node.style.setProperty(CUSTOM_PROPERTY_NAME, String(this.state.ratio));
+        node.style.setProperty(CUSTOM_PROPERTY_NAME, `(${this.state.ratio})`);
       }
     }
   }
@@ -62,7 +62,8 @@ class AspectRatio extends PureComponent<Props, State> {
     } = this.props; // eslint-disable-line no-unused-vars
 
     const newStyle = {
-      [CUSTOM_PROPERTY_NAME]: this.state.ratio,
+      // https://github.com/roderickhsiao/react-aspect-ratio/commit/53ec15858ae186c41e70b8c14cc5a5b6e97cb6e3
+      [CUSTOM_PROPERTY_NAME]: `(${this.state.ratio})`,
       ...style
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import { polyfill } from 'react-lifecycles-compat';
 const CUSTOM_PROPERTY_NAME = '--aspect-ratio';
 
 type Props = {
-  ratio: string | number,
+  ratio: string | number, // eslint-disable-line
   style: Object,
   children: Object
 };

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -45,6 +45,19 @@ storiesOf('AspectRatio', module)
       />
     </Fragment>
   ))
+  .add('Image with number', () => (
+    <Fragment>
+      <PageTitle />
+      <Card
+        titleText="Image with Aspect Ratio"
+        contentNode={(
+          <AspectRatio ratio={0.75} style={{ maxWidth: '400px' }}>
+            <img src="https://c1.staticflickr.com/4/3896/14550191836_cc0675d906.jpg" alt="demo" />
+          </AspectRatio>
+)}
+      />
+    </Fragment>
+  ))
   .add('Background Image', () => (
     <Fragment>
       <PageTitle />


### PR DESCRIPTION
Discuss thread over here.

https://github.com/roderickhsiao/react-aspect-ratio/commit/53ec15858ae186c41e70b8c14cc5a5b6e97cb6e3

The CSS minification process remove the parentheses which might break the style. The fix is to ways wrap the variable with parentheses to support both cases.

@huyz
