### PR TITLE
Allow all div props to be passed to `AspectRatio`

### DIFF
--- a/src/react-15.6.tsx
+++ b/src/react-15.6.tsx
@@ -1,13 +1,9 @@
 import { Component } from 'react';
 
+import type { Props } from './types';
+
 const CUSTOM_PROPERTY_NAME = '--aspect-ratio';
 const DEFAULT_CLASS_NAME = 'react-aspect-ratio-placeholder';
-
-type Props = React.PropsWithChildren<{
-  className?: string;
-  ratio?: string | number;
-  style?: React.CSSProperties;
-}>;
 
 class AspectRatio extends Component<Props> {
   static defaultProps = {

--- a/src/react-latest.tsx
+++ b/src/react-latest.tsx
@@ -1,11 +1,7 @@
+import type { Props } from './types';
+
 const CUSTOM_PROPERTY_NAME = '--aspect-ratio';
 const DEFAULT_CLASS_NAME = 'react-aspect-ratio-placeholder';
-
-type Props = React.PropsWithChildren<{
-  className?: string;
-  ratio?: string | number;
-  style?: React.CSSProperties;
-}>;
 
 function AspectRatio(props: Props) {
   const {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export type Props = React.ComponentProps<'div'> & {
+  ratio?: string | number;
+};


### PR DESCRIPTION
👋 tiny PR - currently, `AspectRatio` only accepts a handful of props:

https://github.com/roderickhsiao/react-aspect-ratio/blob/a52f99bc8923c75199c351aea3e6804cc0ba5955/src/react-latest.tsx#L4-L8

However, this prevents relatively simple cases like passing a ref:
```tsx
function SomeComponent() {
  const ref = useRef<HTMLDivElement>(null);

  return (
    // Property 'ref' does not exist on type 'IntrinsicAttributes & { className?: string; ratio?: string | number; style?: CSSProperties; } & { children?: ReactNode; }'
    <AspectRatio ref={ref}>
      some content
    </AspectRatio>
  );
}
```

This PR expands the prop definition to use `React.ComponentProps<'div'>` in addition to the extra `ratio` prop.