### PR TITLE
Support passing refs to `AspectRatio`

### DIFF
--- a/src/react-latest.tsx
+++ b/src/react-latest.tsx
@@ -1,9 +1,10 @@
+import { forwardRef } from 'react';
 import type { Props } from './types';
 
 const CUSTOM_PROPERTY_NAME = '--aspect-ratio';
 const DEFAULT_CLASS_NAME = 'react-aspect-ratio-placeholder';
 
-function AspectRatio(props: Props) {
+const AspectRatio = forwardRef<HTMLDivElement, Props>((props, ref) => {
   const {
     className = DEFAULT_CLASS_NAME,
     children,
@@ -19,10 +20,10 @@ function AspectRatio(props: Props) {
   } as React.CSSProperties;
 
   return (
-    <div className={className} style={newStyle} {...restProps}>
+    <div className={className} style={newStyle} ref={ref} {...restProps}>
       {children}
     </div>
   );
-}
+});
 
 export default AspectRatio;


### PR DESCRIPTION
The types from #78 suggest that passing `ref`s to `AspectRatio` is supported just like a native `div`, but this currently results in a dev warning that the ref isn't being passed to the underlying functional component.

This PR updates `AspectRatio` to use `forwardRef` to support this behavior.